### PR TITLE
Fix NullPointerException in MyWebViewClient

### DIFF
--- a/app/src/main/java/com/example/app/MyWebViewClient.java
+++ b/app/src/main/java/com/example/app/MyWebViewClient.java
@@ -9,7 +9,8 @@ public class MyWebViewClient extends WebViewClient {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        if (Uri.parse(url).getHost().endsWith("example.com")) {
+        Uri uri = Uri.parse(url);
+        if (uri.getHost() != null && uri.getHost().contains("example.com")) {
             return false;
         }
 


### PR DESCRIPTION
If the user clicks on a `mailto:` link or a phone number, it will cause a NullPointerException when calling `getHost()`.