### PR TITLE
add: android:configChanges=orientation|screenSize to manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
+            android:configChanges="orientation|screenSize"
             android:name="com.example.app.MainActivity"
             android:label="@string/app_name" >
             <intent-filter>


### PR DESCRIPTION
So I had an issue with the screen reloading on rotate and sending my SPA app back to the main page. This config I found from stackoverflow fixed it. [https://stackoverflow.com/questions/12131025/android-preventing-webview-reload-on-rotate](https://stackoverflow.com/questions/12131025/android-preventing-webview-reload-on-rotate)